### PR TITLE
Add roundtable view for group chat conversations

### DIFF
--- a/chatbot/components/agent-chat/__tests__/group-roundtable-view.test.tsx
+++ b/chatbot/components/agent-chat/__tests__/group-roundtable-view.test.tsx
@@ -1,0 +1,197 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { GroupRoundtableView, bucketOf, arcFor, USER_BUCKET } from "../group-roundtable-view";
+import type { AgentConfigEntry } from "@@/lib/agents-config-schemas";
+import type { ChatMessage } from "@/components/hooks/use-messages";
+
+const mockIcon = () => null;
+
+vi.mock("@@/lib/agents", () => ({
+  buildAgentDef: (entry: AgentConfigEntry) => ({
+    icon: mockIcon,
+    iconBg: `bg-${entry.name}`,
+    iconColor: `text-${entry.name}`,
+    displayName: entry.displayName,
+    doveCard: entry.doveCard,
+  }),
+}));
+vi.mock("@/lib/avatars", () => ({ DOVE_AVATAR: "/dove.webp", USER_AVATAR: "/user.webp" }));
+vi.mock("animejs", () => ({ animate: vi.fn() }));
+vi.mock("../animated-message", () => ({
+  AnimatedMessage: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../copy-action", () => ({ CopyAction: () => null }));
+vi.mock("../tool-call-badge", () => ({ EditDiffList: () => null, ToolCallItem: () => null }));
+vi.mock("@/components/ai-elements/message", () => ({
+  MessageContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  MessageResponse: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/components/ai-elements/reasoning", () => ({
+  Reasoning: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ReasoningContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ReasoningTrigger: () => null,
+}));
+vi.mock("@/components/ai-elements/shimmer", () => ({
+  Shimmer: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+}));
+
+const makeAgent = (name: string): AgentConfigEntry => ({
+  name,
+  alias: name,
+  displayName: name.toUpperCase(),
+  description: "",
+  iconName: "Bot",
+  iconBg: "",
+  iconColor: "",
+  doveCard: { title: "", description: "", prompt: "", iconName: "Bot" },
+  suggestions: [],
+});
+
+const agentConfigs: AgentConfigEntry[] = [makeAgent("alpha"), makeAgent("beta")];
+
+const text = (content: string): ChatMessage["segments"] => [{ type: "text", content }];
+
+describe("bucketOf", () => {
+  it("buckets assistant messages by agentId", () => {
+    expect(
+      bucketOf({ id: "1", role: "assistant", segments: text("hi"), agentId: "alpha" }),
+    ).toBe("alpha");
+  });
+
+  it("buckets human-typed user messages into the user slot", () => {
+    expect(
+      bucketOf({ id: "1", role: "user", segments: text("hi"), agentId: "alpha" }),
+    ).toBe(USER_BUCKET);
+  });
+
+  it("buckets orchestrator user messages by senderAgentId", () => {
+    expect(
+      bucketOf({
+        id: "1",
+        role: "user",
+        segments: text("instruction"),
+        agentId: "alpha",
+        senderAgentId: "alpha",
+      }),
+    ).toBe("alpha");
+  });
+});
+
+describe("arcFor", () => {
+  it("draws user → recipient for human-typed messages", () => {
+    const msgs: ChatMessage[] = [
+      { id: "1", role: "user", segments: text("hi"), agentId: "alpha" },
+    ];
+    expect(arcFor(msgs, 0)).toEqual({ from: USER_BUCKET, to: "alpha", msgId: "1" });
+  });
+
+  it("draws prev-bucket → current for assistant replies", () => {
+    const msgs: ChatMessage[] = [
+      { id: "1", role: "user", segments: text("hi"), agentId: "alpha" },
+      { id: "2", role: "assistant", segments: text("hello"), agentId: "alpha" },
+    ];
+    expect(arcFor(msgs, 1)).toEqual({ from: USER_BUCKET, to: "alpha", msgId: "2" });
+  });
+
+  it("returns null when no prior message has a different bucket", () => {
+    const msgs: ChatMessage[] = [
+      { id: "1", role: "assistant", segments: text("hi"), agentId: "alpha" },
+    ];
+    expect(arcFor(msgs, 0)).toBeNull();
+  });
+
+  it("skips arcs for orchestrator user messages with no recipient encoded", () => {
+    const msgs: ChatMessage[] = [
+      {
+        id: "1",
+        role: "user",
+        segments: text("go"),
+        agentId: "alpha",
+        senderAgentId: "alpha",
+      },
+    ];
+    expect(arcFor(msgs, 0)).toBeNull();
+  });
+});
+
+describe("GroupRoundtableView layout", () => {
+  it("renders an avatar slot per member plus the user", () => {
+    const { container } = render(
+      <GroupRoundtableView
+        messages={[]}
+        memberAgentIds={["alpha", "beta"]}
+        agentConfigs={agentConfigs}
+      />,
+    );
+    const slots = container.querySelectorAll("[data-bucket]");
+    expect(slots.length).toBe(3);
+    const buckets = Array.from(slots).map((el) => el.getAttribute("data-bucket"));
+    expect(buckets).toContain("alpha");
+    expect(buckets).toContain("beta");
+    expect(buckets).toContain(USER_BUCKET);
+  });
+
+  it("shows only the latest message per bucket by default", () => {
+    const messages: ChatMessage[] = [
+      { id: "a1", role: "assistant", segments: text("first from alpha"), agentId: "alpha" },
+      { id: "a2", role: "assistant", segments: text("second from alpha"), agentId: "alpha" },
+      { id: "b1", role: "assistant", segments: text("only from beta"), agentId: "beta" },
+    ];
+    const { container } = render(
+      <GroupRoundtableView
+        messages={messages}
+        memberAgentIds={["alpha", "beta"]}
+        agentConfigs={agentConfigs}
+      />,
+    );
+    const alphaSlot = container.querySelector('[data-bucket="alpha"]')!;
+    expect(alphaSlot.textContent).toContain("second from alpha");
+    expect(alphaSlot.textContent).not.toContain("first from alpha");
+  });
+
+  it("expands the bubble stack when the avatar is clicked", () => {
+    const messages: ChatMessage[] = [
+      { id: "a1", role: "assistant", segments: text("oldest"), agentId: "alpha" },
+      { id: "a2", role: "assistant", segments: text("middle"), agentId: "alpha" },
+      { id: "a3", role: "assistant", segments: text("newest"), agentId: "alpha" },
+    ];
+    const { container } = render(
+      <GroupRoundtableView
+        messages={messages}
+        memberAgentIds={["alpha"]}
+        agentConfigs={agentConfigs}
+      />,
+    );
+    const slot = container.querySelector('[data-bucket="alpha"]')!;
+    const avatarBtn = slot.querySelector("button")!;
+    expect(slot.textContent).not.toContain("oldest");
+    fireEvent.click(avatarBtn);
+    const slotAfter = container.querySelector('[data-bucket="alpha"]')!;
+    expect(slotAfter.textContent).toContain("oldest");
+    expect(slotAfter.textContent).toContain("middle");
+    expect(slotAfter.textContent).toContain("newest");
+  });
+
+  it("marks an agent slot as active when its latest message is loading", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "a1",
+        role: "assistant",
+        segments: text("streaming…"),
+        agentId: "alpha",
+        isLoading: true,
+      },
+    ];
+    const { container } = render(
+      <GroupRoundtableView
+        messages={messages}
+        memberAgentIds={["alpha", "beta"]}
+        agentConfigs={agentConfigs}
+      />,
+    );
+    const alpha = container.querySelector('[data-bucket="alpha"]')!;
+    const beta = container.querySelector('[data-bucket="beta"]')!;
+    expect(alpha.getAttribute("data-active")).toBe("true");
+    expect(beta.getAttribute("data-active")).toBe("false");
+  });
+});

--- a/chatbot/components/agent-chat/group-chat-view.tsx
+++ b/chatbot/components/agent-chat/group-chat-view.tsx
@@ -9,6 +9,7 @@ import { Conversation, ConversationContent } from "@/components/ai-elements/conv
 import { ChatMessageItem } from "./chat-message";
 import { ChatInputBar } from "./chat-input-bar";
 import { ProcessingBar } from "./processing-bar";
+import { GroupRoundtableView } from "./group-roundtable-view";
 import { useGroupChatSession } from "@/components/hooks/use-group-chat-session";
 
 interface GroupChatViewProps {
@@ -44,6 +45,7 @@ export function GroupChatView({
     }
   }, [isLoading, onIsLoadingChange]);
   const [selectedAgentId, setSelectedAgentId] = React.useState(memberAgentIds[0] ?? "");
+  const [viewMode, setViewMode] = React.useState<"stacked" | "roundtable">("stacked");
 
   const configByName = React.useMemo(
     () => new Map(agentConfigs.map((a) => [a.name, a])),
@@ -66,7 +68,24 @@ export function GroupChatView({
           Group Chat
         </span>
 
-        <div className="flex -space-x-1 ml-auto">
+        <div className="ml-auto flex items-center gap-3">
+          <div className="flex items-center rounded-full border border-border/50 p-0.5 text-[10px] font-bold tracking-wider uppercase">
+            {(["stacked", "roundtable"] as const).map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                onClick={() => setViewMode(mode)}
+                className={`px-2.5 py-0.5 rounded-full transition-colors ${
+                  viewMode === mode
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {mode}
+              </button>
+            ))}
+          </div>
+          <div className="flex -space-x-1">
           {memberAgentIds.map((agentId) => {
             const config = configByName.get(agentId);
             if (!config) return null;
@@ -81,6 +100,7 @@ export function GroupChatView({
               </div>
             );
           })}
+          </div>
         </div>
       </header>
 
@@ -92,6 +112,12 @@ export function GroupChatView({
                 No messages yet. Start the conversation.
               </p>
             </div>
+          ) : viewMode === "roundtable" ? (
+            <GroupRoundtableView
+              messages={messages}
+              memberAgentIds={memberAgentIds}
+              agentConfigs={agentConfigs}
+            />
           ) : (
             messages.map((msg, i) => {
               const prevMsg = messages[i - 1];

--- a/chatbot/components/agent-chat/group-roundtable-view.tsx
+++ b/chatbot/components/agent-chat/group-roundtable-view.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import * as React from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { animate } from "animejs";
+import { buildAgentDef } from "@@/lib/agents";
+import type { AgentConfigEntry } from "@@/lib/agents-config-schemas";
+import { USER_AVATAR } from "@/lib/avatars";
+import type { ChatMessage } from "@/components/hooks/use-messages";
+import { messageText } from "@/components/hooks/use-messages";
+import { ChatMessageItem } from "./chat-message";
+
+export const USER_BUCKET = "__user__";
+
+export function bucketOf(msg: ChatMessage): string {
+  if (msg.role === "assistant") return msg.agentId ?? USER_BUCKET;
+  if (msg.senderAgentId) return msg.senderAgentId;
+  return USER_BUCKET;
+}
+
+export interface ArcEvent {
+  from: string;
+  to: string;
+  msgId: string;
+}
+
+export function arcFor(messages: ChatMessage[], idx: number): ArcEvent | null {
+  const msg = messages[idx];
+  if (!msg) return null;
+  if (msg.role === "user" && !msg.senderAgentId) {
+    if (msg.agentId) return { from: USER_BUCKET, to: msg.agentId, msgId: msg.id };
+    return null;
+  }
+  if (msg.role === "user" && msg.senderAgentId) return null;
+  const target = bucketOf(msg);
+  for (let i = idx - 1; i >= 0; i--) {
+    const prev = bucketOf(messages[i]);
+    if (prev !== target) return { from: prev, to: target, msgId: msg.id };
+  }
+  return null;
+}
+
+interface GroupRoundtableViewProps {
+  messages: ChatMessage[];
+  memberAgentIds: string[];
+  agentConfigs: AgentConfigEntry[];
+}
+
+interface SlotPosition {
+  bucket: string;
+  cxPct: number;
+  cyPct: number;
+}
+
+const RING_RADIUS_PCT = 36;
+
+function computePositions(buckets: string[]): SlotPosition[] {
+  const n = buckets.length;
+  if (n === 0) return [];
+  if (n === 1) return [{ bucket: buckets[0], cxPct: 50, cyPct: 50 }];
+  return buckets.map((bucket, i) => {
+    const angle = -Math.PI / 2 + (2 * Math.PI * i) / n;
+    return {
+      bucket,
+      cxPct: 50 + RING_RADIUS_PCT * Math.cos(angle),
+      cyPct: 50 + RING_RADIUS_PCT * Math.sin(angle),
+    };
+  });
+}
+
+export function GroupRoundtableView({
+  messages,
+  memberAgentIds,
+  agentConfigs,
+}: GroupRoundtableViewProps) {
+  const buckets = useMemo(() => [USER_BUCKET, ...memberAgentIds], [memberAgentIds]);
+  const positions = useMemo(() => computePositions(buckets), [buckets]);
+  const positionByBucket = useMemo(
+    () => new Map(positions.map((p) => [p.bucket, p])),
+    [positions],
+  );
+
+  const configByName = useMemo(
+    () => new Map(agentConfigs.map((a) => [a.name, a])),
+    [agentConfigs],
+  );
+
+  const messagesByBucket = useMemo(() => {
+    const map = new Map<string, ChatMessage[]>();
+    for (const m of messages) {
+      const b = bucketOf(m);
+      const list = map.get(b);
+      if (list) list.push(m);
+      else map.set(b, [m]);
+    }
+    return map;
+  }, [messages]);
+
+  const [expandedBucket, setExpandedBucket] = useState<string | null>(null);
+  const toggleExpanded = (bucket: string) =>
+    setExpandedBucket((prev) => (prev === bucket ? null : bucket));
+
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const lastAnimatedMsgIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const svg = svgRef.current;
+    if (!svg || messages.length === 0) return;
+    const lastIdx = messages.length - 1;
+    const lastMsg = messages[lastIdx];
+    if (lastMsg.id === lastAnimatedMsgIdRef.current) return;
+    lastAnimatedMsgIdRef.current = lastMsg.id;
+    const arc = arcFor(messages, lastIdx);
+    if (!arc) return;
+    const fromPos = positionByBucket.get(arc.from);
+    const toPos = positionByBucket.get(arc.to);
+    if (!fromPos || !toPos) return;
+
+    const path = svg.ownerDocument.createElementNS("http://www.w3.org/2000/svg", "path");
+    const mx = (fromPos.cxPct + toPos.cxPct) / 2;
+    const my = (fromPos.cyPct + toPos.cyPct) / 2;
+    const dx = toPos.cxPct - fromPos.cxPct;
+    const dy = toPos.cyPct - fromPos.cyPct;
+    const cx = mx - dy * 0.25;
+    const cy = my + dx * 0.25;
+    path.setAttribute("d", `M ${fromPos.cxPct} ${fromPos.cyPct} Q ${cx} ${cy} ${toPos.cxPct} ${toPos.cyPct}`);
+    path.setAttribute("fill", "none");
+    path.setAttribute("stroke", "currentColor");
+    path.setAttribute("stroke-width", "0.4");
+    path.setAttribute("stroke-linecap", "round");
+    path.setAttribute("class", "text-primary");
+    svg.appendChild(path);
+
+    const length = path.getTotalLength?.() ?? 100;
+    path.style.strokeDasharray = String(length);
+    path.style.strokeDashoffset = String(length);
+    path.style.opacity = "0.9";
+
+    animate(path, {
+      strokeDashoffset: [length, 0],
+      duration: 700,
+      easing: "easeOutCubic",
+      complete: () => {
+        animate(path, {
+          opacity: [0.9, 0],
+          duration: 800,
+          easing: "linear",
+          complete: () => path.parentNode?.removeChild(path),
+        });
+      },
+    });
+  }, [messages, positionByBucket]);
+
+  return (
+    <div className="relative w-full max-w-[640px] mx-auto aspect-square">
+      <svg
+        ref={svgRef}
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        className="absolute inset-0 w-full h-full pointer-events-none"
+        aria-hidden="true"
+      />
+      {positions.map((pos) => {
+        const bucketMessages = messagesByBucket.get(pos.bucket) ?? [];
+        const latest = bucketMessages[bucketMessages.length - 1];
+        const isUser = pos.bucket === USER_BUCKET;
+        const config = isUser ? null : configByName.get(pos.bucket);
+        const isActive = !!latest?.isLoading;
+        const isExpanded = expandedBucket === pos.bucket;
+        const displayName = isUser ? "You" : (config?.displayName ?? pos.bucket);
+        const def = config ? buildAgentDef(config) : null;
+        const Icon = def?.icon;
+        return (
+          <div
+            key={pos.bucket}
+            data-bucket={pos.bucket}
+            data-active={isActive ? "true" : "false"}
+            className="absolute -translate-x-1/2 -translate-y-1/2 flex flex-col items-center gap-2 w-44"
+            style={{ left: `${pos.cxPct}%`, top: `${pos.cyPct}%` }}
+          >
+            <button
+              type="button"
+              onClick={() => toggleExpanded(pos.bucket)}
+              aria-label={`Toggle ${displayName} messages`}
+              className={`relative w-12 h-12 rounded-2xl shadow-sm flex items-center justify-center transition-transform hover:scale-105 ${
+                isUser ? "bg-secondary border-2 border-secondary overflow-hidden" : (def?.iconBg ?? "bg-muted")
+              } ${isActive ? "ring-2 ring-primary animate-pulse" : ""}`}
+            >
+              {isUser ? (
+                <img src={USER_AVATAR} alt="You" className="w-full h-full object-cover" />
+              ) : Icon ? (
+                <Icon className={`w-6 h-6 ${def?.iconColor ?? ""}`} />
+              ) : null}
+            </button>
+            <div className="text-[11px] font-semibold text-foreground leading-none">
+              {displayName}
+            </div>
+            <div className="w-full">
+              {isExpanded ? (
+                <ExpandedStack messages={bucketMessages} agentConfigs={agentConfigs} />
+              ) : latest ? (
+                <ClosedBubble msg={latest} />
+              ) : (
+                <div className="text-[10px] text-muted-foreground/60 text-center italic">idle</div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ClosedBubble({ msg }: { msg: ChatMessage }) {
+  const text = messageText(msg).trim();
+  const preview = text.length > 80 ? `${text.slice(0, 80)}…` : text;
+  return (
+    <div className="rounded-xl bg-muted/70 border border-border/40 px-3 py-1.5 text-[11px] leading-snug text-foreground/90 line-clamp-3 text-center">
+      {preview || (msg.isLoading ? "…" : "")}
+    </div>
+  );
+}
+
+function ExpandedStack({
+  messages,
+  agentConfigs,
+}: {
+  messages: ChatMessage[];
+  agentConfigs: AgentConfigEntry[];
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [messages.length]);
+  return (
+    <div
+      ref={ref}
+      className="rounded-xl bg-background/95 border border-primary/30 shadow-md p-2 max-h-64 overflow-y-auto flex flex-col gap-2"
+    >
+      {messages.map((m) => (
+        <ChatMessageItem
+          key={m.id}
+          msg={m}
+          agentConfigs={agentConfigs}
+          hideReasoning
+          hideAvatars
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Introduces a new "roundtable" visualization mode for group chat conversations that displays participants arranged in a circle with animated message flow arcs between them.

## Key Changes
- **New `GroupRoundtableView` component** (`group-roundtable-view.tsx`):
  - Arranges chat participants (agents + user) in a circular layout
  - Displays the latest message from each participant in a compact bubble
  - Supports expanding individual participant bubbles to view full message history
  - Animates arcs between participants to visualize message flow using anime.js
  - Includes helper functions `bucketOf()` and `arcFor()` to track message routing

- **View mode toggle in `GroupChatView`**:
  - Added "stacked" vs "roundtable" mode selector in the header
  - Conditionally renders `GroupRoundtableView` when roundtable mode is active
  - Maintains existing stacked message view as the default mode

- **Comprehensive test coverage** (`group-roundtable-view.test.tsx`):
  - Tests for message bucketing logic
  - Tests for arc animation triggering
  - Tests for layout, expansion, and active state rendering

## Implementation Details
- Participants are positioned on a circle using trigonometric calculations (36% radius)
- Message arcs are drawn as quadratic Bézier curves with stroke animation
- Each participant slot shows their latest message or "idle" status
- Clicking an avatar expands that participant's message stack with auto-scroll to latest
- Active participants (with loading messages) are highlighted with a pulsing ring
- The roundtable view is non-interactive (pointer-events-none on SVG) to avoid interfering with message bubbles

https://claude.ai/code/session_0158hnjef5pyBjgPHxXrN1p8